### PR TITLE
Updated react and rn version as to support new version for apps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "app-barcode-generator",
+	"name": "@janiscommerce/app-barcode-generator",
 	"version": "1.2.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "app-barcode-generator",
+			"name": "@janiscommerce/app-barcode-generator",
 			"version": "1.2.0",
 			"dependencies": {
 				"@kichiyaki/react-native-barcode-generator": "^0.6.7",
@@ -33,8 +33,8 @@
 				"typescript": "4.8.4"
 			},
 			"peerDependencies": {
-				"react": "18.2.0",
-				"react-native": "0.71.5"
+				"react": ">=17.0.2 <19.0.0",
+				"react-native": ">=0.67.5 <0.75.0"
 			}
 		},
 		"node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
 		"react-qr-code": "^2.0.13"
 	},
 	"peerDependencies": {
-		"react": "18.2.0",
-		"react-native": "0.71.5"
+		"react": ">=17.0.2 <19.0.0",
+		"react-native": ">=0.67.5 <0.75.0"
 	},
 	"files": [
 		"dist/"


### PR DESCRIPTION
## LINK DE TICKET:
https://janiscommerce.atlassian.net/browse/APPSRN-444

## DESCRIPCIÓN DEL REQUERIMIENTO:
Se requieren realizar ciertos ajustes a la librería para que la misma soporte la actualización de versión de React y React Native de las APPs y, a la vez, nos permita eliminar las flags de --legacy-peer-deps / --force a la hora de tirar un npm i dentro del repo de las APPs.

## DESCRIPCIÓN DE LA SOLUCIÓN:
Los ajustes que se hicieron fueron:

Ajustar las peerDependencies

react: 18.2.0 → >=17.0.2 <19.0.0

react-native: 0.71.5 → >=0.67.5 <0.75.0

## CÓMO PROBAR?

Vincular el pkg a la app.
El escaneo debe seguir funcionando correctamente.

## DATOS EXTRA A TENER EN CUENTA:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded peer dependency version ranges for React (17.0.2–18.x) and React Native (0.67.5–0.74.x) to improve compatibility with a wider range of ecosystem versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->